### PR TITLE
Added Access-Control-Allow-Origin * headers

### DIFF
--- a/src/component_handler.erl
+++ b/src/component_handler.erl
@@ -8,7 +8,7 @@
 -record(state, {
 }).
 
--define(JSON_HEADER, [{<<"content-type">>, <<"application/json">>}]).
+-define(JSON_HEADER, [{<<"content-type">>, <<"application/json">>}, {<<"Access-Control-Allow-Origin">>, <<"*">>}]).
 
 init(_, Req, _Opts) ->
 	{ok, Req, #state{}}.


### PR DESCRIPTION
So the browser doesn't complain when fetching components. I didn't find any more places to define this, there might be, but I don't speak Erlang :-) And I didn't run any test either... sorry.
